### PR TITLE
fix: add SBT installation to scala.yml workflow

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -27,6 +27,12 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: 'sbt'
+    
+    - name: Setup SBT
+      uses: sbt/setup-sbt@v1
+      with:
+        sbt-version: 1.9.7
+    
     - name: Run tests
       run: sbt test
       # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository


### PR DESCRIPTION
## 🔧 Fix Missing SBT Installation in scala.yml

This PR fixes the missing SBT installation step in the `scala.yml` GitHub workflow that was causing build failures.

## 📋 Problem Fixed

- **❌ Before:** `scala.yml` was trying to run `sbt test` without ensuring SBT was installed
- **✅ After:** Added proper SBT installation step using the official `sbt/setup-sbt@v1` action

## 🔧 Changes Made

### Added SBT Installation Step:
```yaml
- name: Setup SBT
  uses: sbt/setup-sbt@v1
  with:
    sbt-version: 1.9.7
```

### Updated Workflow Flow:
```
Checkout → Setup Java 17 → Setup SBT 1.9.7 → Run Tests → Upload Dependency Graph
```

## ✅ Benefits

- **Reliable SBT Availability** - Ensures SBT 1.9.7 is installed before use
- **Consistent with Other Workflows** - Matches `ci.yml` and `release.yml` patterns  
- **No More Build Failures** - Eliminates potential `sbt: command not found` errors
- **Version Consistency** - Uses the same SBT version (1.9.7) across all workflows

## 🧪 Testing

The workflow will now:
- ✅ Install SBT 1.9.7 reliably
- ✅ Run `sbt test` successfully  
- ✅ Upload dependency graph to GitHub
- ✅ Enable Dependabot alerts

## 📊 Impact

This ensures the Scala CI workflow runs successfully and maintains consistency across all GitHub Actions workflows in the repository.